### PR TITLE
Base._return_type -> MA.promote_operation

### DIFF
--- a/src/arithmetic.jl
+++ b/src/arithmetic.jl
@@ -1,10 +1,10 @@
 function _preallocate_output(X::AlgebraElement, a::Number, op)
-    T = Base._return_type(op, Tuple{eltype(X),typeof(a)})
+    T = MA.promote_operation(op, eltype(X), typeof(a))
     return similar(X, T)
 end
 
 function _preallocate_output(X::AlgebraElement, Y::AlgebraElement, op)
-    T = Base._return_type(op, Tuple{eltype(X),eltype(Y)})
+    T = MA.promote_operation(op, eltype(X), eltype(Y))
     if coeffs(Y) isa DenseArray # what a hack :)
         return similar(Y, T)
     end

--- a/src/coefficients.jl
+++ b/src/coefficients.jl
@@ -98,7 +98,7 @@ end
 
 function LinearAlgebra.dot(ac::AbstractCoefficients, bc::AbstractCoefficients)
     if isempty(values(ac)) || isempty(values(bc))
-        return zero(Base._return_type(*, Tuple{valtype(ac),valtype(bc)}))
+        return zero(MA.promote_sum_mul(valtype(ac), valtype(bc)))
     else
         return sum(c * star(bc[i]) for (i, c) in nonzero_pairs(ac))
     end
@@ -107,7 +107,7 @@ end
 function LinearAlgebra.dot(w::AbstractVector, ac::AbstractCoefficients)
     @assert key_type(ac) <: Integer
     if isempty(values(ac))
-        return zero(Base._return_type(*, eltype(w), valtype(ac)))
+        return zero(MA.promote_sum_mul(eltype(w), valtype(ac)))
     else
         return sum(w[i] * star(v) for (i, v) in nonzero_pairs(ac))
     end
@@ -116,7 +116,7 @@ end
 function LinearAlgebra.dot(ac::AbstractCoefficients, w::AbstractVector)
     @assert key_type(ac) <: Integer
     if isempty(values(ac))
-        return zero(Base._return_type(*, eltype(w), valtype(ac)))
+        return zero(MA.promote_sum_mul(eltype(w), valtype(ac)))
     else
         return sum(v * star(w[i]) for (i, v) in nonzero_pairs(ac))
     end

--- a/src/sparse_coeffs.jl
+++ b/src/sparse_coeffs.jl
@@ -53,13 +53,13 @@ end
 
 ### temporary convenience? how to handle this?
 function __prealloc(X::SparseCoefficients, a::Number, op)
-    T = Base._return_type(op, Tuple{valtype(X),typeof(a)})
+    T = MA.promote_operation(op, valtype(X), typeof(a))
     return similar(X, T)
 end
 
 function __prealloc(X::SparseCoefficients, Y::SparseCoefficients, op)
     # this is not even correct for op = *
-    T = Base._return_type(op, Tuple{valtype(X),valtype(Y)})
+    T = MA.promote_operation(op, valtype(X), valtype(Y))
     return similar(X, T)
 end
 


### PR DESCRIPTION
The purpose of `promote_operation` is to have a function that's safe to call but only for common arithmetic operation. Here, we only need it for the operation for which `promote_operation` should work so it's a clear call.