### PR TITLE
Fix all broken tests but one

### DIFF
--- a/src/arithmetic.jl
+++ b/src/arithmetic.jl
@@ -92,8 +92,7 @@ function MA.operate_to!(
     Y::AlgebraElement,
 )
     @assert parent(res) === parent(X) === parent(Y)
-    MA.operate_to!(coeffs(res), -, coeffs(Y))
-    MA.operate_to!(coeffs(res), +, coeffs(res), coeffs(X))
+    MA.operate_to!(coeffs(res), -, coeffs(X), coeffs(Y))
     return res
 end
 

--- a/test/caching_allocations.jl
+++ b/test/caching_allocations.jl
@@ -61,10 +61,7 @@ end
         YY = deepcopy(Y)
         _alloc_test(YY, *, Y, Y, 25)
         _alloc_test(YY, +, Y, Y, 0)
-        @test_broken 1 == 2 # it's actually the one below:
-        # [2] operate_to!(output::SparseVector{Float64, Int64}, op::typeof(-), args::SparseVector{Float64, Int64})
-        #   @ MutableArithmetics ~/.julia/packages/MutableArithmetics/iovKe/src/interface.jl:391
-        # _alloc_test(YY, -, Y, Y, 0)
+        _alloc_test(YY, -, Y, Y, 0)
 
         # SparseArrays calls `Base.unalias` which allocates:
         _alloc_test(YY, +, YY, Y, 2)

--- a/test/group_algebra.jl
+++ b/test/group_algebra.jl
@@ -184,15 +184,7 @@
 
                     @test P2 * P3 == P3 * P2 == P
 
-                    #=
-
-                    Stacktrace:
-                    [1] operate_to_fallback!(::MutableArithmetics.IsNotMutable, output::SparseVector{Int64, UInt32}, op::Function, args::SparseVector{Int64, UInt32})
-                    @ MutableArithmetics ~/.julia/dev/MutableArithmetics/src/interface.jl:350
-                    [2] operate_to!(output::SparseVector{Int64, UInt32}, op::typeof(-), args::SparseVector{Int64, UInt32})
-                    @ MutableArithmetics ~/.julia/dev/MutableArithmetics/src/interface.jl:391
-                    =#
-                    @test_broken -RG(h)
+                    @test_broken -RG(h) == (-1) * RG(h)
                     @test !iszero(RG(1) - RG(h))
 
                     P2m = (RG(1) - RG(h)) // 2

--- a/test/group_algebra.jl
+++ b/test/group_algebra.jl
@@ -160,11 +160,7 @@
 
                     @test 2dfP // 2 == dfP
 
-                    #= broken by
-                       [12] operate_to!(output::Vector{Rational{Int64}}, op::typeof(-), args::Vector{Rational{Int64}})
-                    @ MutableArithmetics ~/.julia/dev/MutableArithmetics/src/interface.jl:391
-                    =#
-                    @test_broken (dfP + fP) - dfP == dfP
+                    @test (dfP + fP) - dfP == dfP
                 end
 
                 @testset "Projections" begin
@@ -197,15 +193,13 @@
                     @ MutableArithmetics ~/.julia/dev/MutableArithmetics/src/interface.jl:391
                     =#
                     @test_broken -RG(h)
-                    @test_broken RG(1) - RG(h)
-                    @test_broken !iszero(RG(1) - RG(h))
+                    @test !iszero(RG(1) - RG(h))
 
-                    # uncomment this after the above are unbroken
-                    # P2m = (RG(1) - RG(h)) // 2
-                    # @test P2m * P2m == P2m
+                    P2m = (RG(1) - RG(h)) // 2
+                    @test P2m * P2m == P2m
 
-                    @test_broken P2m * P3 == P3 * P2m == PAlt
-                    @test_broken iszero(P2m * P2)
+                    @test P2m * P3 == P3 * P2m == PAlt
+                    @test iszero(P2m * P2)
                 end
             end
         end


### PR DESCRIPTION
I started by implementing `operate_to(res, -, a)` for `AbstractArray`s but then `Base.broadcast!` would allocate in `MA.operate_to!(coeffs(res), +, coeffs(res), coeffs(X))` when it would unalias the result from the first argument since they are the same.
By merging the two in one line we have a call to `Base.broadcast!` with no alias so it seems better :)