### PR TITLE
Implement == for algebra

### DIFF
--- a/src/arithmetic.jl
+++ b/src/arithmetic.jl
@@ -91,7 +91,7 @@ function MA.operate_to!(
     X::AlgebraElement,
     Y::AlgebraElement,
 )
-    @assert parent(res) === parent(X) === parent(Y)
+    @assert parent(res) == parent(X) == parent(Y)
     MA.operate_to!(coeffs(res), -, coeffs(Y))
     MA.operate_to!(coeffs(res), +, coeffs(res), coeffs(X))
     return res
@@ -103,7 +103,7 @@ function MA.operate_to!(
     X::AlgebraElement,
     Y::AlgebraElement,
 )
-    @assert parent(res) === parent(X) === parent(Y)
+    @assert parent(res) == parent(X) == parent(Y)
     mstr = mstructure(basis(parent(res)))
     MA.operate_to!(coeffs(res), mstr, coeffs(X), coeffs(Y))
     return res

--- a/src/types.jl
+++ b/src/types.jl
@@ -26,6 +26,9 @@ end
 
 basis(A::StarAlgebra) = A.basis
 object(A::StarAlgebra) = A.object
+function Base.:(==)(a::StarAlgebra, b::StarAlgebra)
+    return a.basis == b.basis
+end
 
 struct AlgebraElement{A,T,V} <: MA.AbstractMutable
     coeffs::V


### PR DESCRIPTION
`===` seems a bit too strong. In MultivariateBases, I may create two separate algebra object but with exactly the same `FullBasis` so I want to be able to do arithmetics between them.
We need to change at other places as well if you agree