### PR TITLE
fix for failing test in allocations

### DIFF
--- a/src/algebra_elts.jl
+++ b/src/algebra_elts.jl
@@ -15,13 +15,13 @@ function Base.deepcopy_internal(a::AlgebraElement, id::IdDict)
 end
 
 # call overload:
-(a::AlgebraElement)(x) = coeffs(a)[basis(parent(a))[x]]
-Base.setindex!(a::AlgebraElement, v, idx) = a.coeffs[basis(parent(a))[idx]] = v
+(a::AlgebraElement)(x) = coeffs(a)[basis(a)[x]]
+Base.setindex!(a::AlgebraElement, v, idx) = a.coeffs[basis(a)[idx]] = v
 
 # AlgebraElement specific functions
 
 function supp(a::AlgebraElement)
-    b = basis(parent(a))
+    b = basis(a)
     return [b[i] for (i, _) in nonzero_pairs(coeffs(a))]
 end
 

--- a/src/arithmetic.jl
+++ b/src/arithmetic.jl
@@ -107,3 +107,14 @@ function MA.operate_to!(
     MA.operate_to!(coeffs(res), mstr, coeffs(X), coeffs(Y))
     return res
 end
+
+# TODO just push to internal vectors once canonical is implemented for SparseVector
+function unsafe_push!(a::SparseArrays.SparseVector, k, v)
+    a[k] = MA.add!!(a[k], v)
+    return v
+end
+
+function unsafe_push!(a::AlgebraElement, k, v)
+    unsafe_push!(coeffs(a), basis(a)[k], v)
+    return a
+end

--- a/src/arithmetic.jl
+++ b/src/arithmetic.jl
@@ -103,7 +103,7 @@ function MA.operate_to!(
     Y::AlgebraElement,
 )
     @assert parent(res) == parent(X) == parent(Y)
-    mstr = mstructure(basis(parent(res)))
+    mstr = mstructure(basis(res))
     MA.operate_to!(coeffs(res), mstr, coeffs(X), coeffs(Y))
     return res
 end

--- a/src/arithmetic.jl
+++ b/src/arithmetic.jl
@@ -91,7 +91,7 @@ function MA.operate_to!(
     X::AlgebraElement,
     Y::AlgebraElement,
 )
-    @assert parent(res) === parent(X) === parent(Y)
+    @assert parent(res) == parent(X) == parent(Y)
     MA.operate_to!(coeffs(res), -, coeffs(X), coeffs(Y))
     return res
 end
@@ -102,7 +102,7 @@ function MA.operate_to!(
     X::AlgebraElement,
     Y::AlgebraElement,
 )
-    @assert parent(res) === parent(X) === parent(Y)
+    @assert parent(res) == parent(X) == parent(Y)
     mstr = mstructure(basis(parent(res)))
     MA.operate_to!(coeffs(res), mstr, coeffs(X), coeffs(Y))
     return res

--- a/src/coefficients.jl
+++ b/src/coefficients.jl
@@ -119,7 +119,11 @@ end
 
 # general mutable API
 # why here?
-MA.operate!(::typeof(zero), v::SparseVector) = (v .= 0; v)
+function MA.operate!(::typeof(zero), v::SparseVector)
+    empty!(SparseArrays.nonzeroinds(v))
+    empty!(SparseArrays.nonzeros(v))
+    return v
+end
 
 Base.zero(X::AbstractCoefficients) = MA.operate!(zero, similar(X))
 Base.:-(X::AbstractCoefficients) = MA.operate_to!(__prealloc(X, -1, *), -, X)

--- a/src/sparse_coeffs.jl
+++ b/src/sparse_coeffs.jl
@@ -101,6 +101,13 @@ function MA.operate!(::typeof(canonical), res::SparseCoefficients, cmp::C) where
     return res
 end
 
+function MA.operate!(
+    ::typeof(canonical),
+    res::SparseCoefficients{T,I,Tuple{T},Tuple{I}},
+) where {T,I}
+    return res
+end
+
 # arithmetic on coefficients; performance overloads
 
 function MA.operate!(::typeof(zero), s::SparseCoefficients)

--- a/src/star.jl
+++ b/src/star.jl
@@ -2,7 +2,7 @@ Base.adjoint(a::AlgebraElement) = star(a)
 star(x::Any) = x'
 
 function star(X::AlgebraElement)
-    res = star(basis(parent(X)), coeffs(X))
+    res = star(basis(X), coeffs(X))
     return AlgebraElement(res, parent(X))
 end
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -36,8 +36,9 @@ Base.parent(a::AlgebraElement) = a.parent
 Base.eltype(a::AlgebraElement) = valtype(coeffs(a))
 coeffs(a::AlgebraElement) = a.coeffs
 function coeffs(x::AlgebraElement, b::AbstractBasis)
-    return coeffs(coeffs(x), basis(parent(x)), b)
+    return coeffs(coeffs(x), basis(x), b)
 end
+basis(a::AlgebraElement) = basis(parent(a))
 
 function AlgebraElement(coeffs, A::AbstractStarAlgebra)
     _sanity_checks(coeffs, A)

--- a/src/types.jl
+++ b/src/types.jl
@@ -26,9 +26,6 @@ end
 
 basis(A::StarAlgebra) = A.basis
 object(A::StarAlgebra) = A.object
-function Base.:(==)(a::StarAlgebra, b::StarAlgebra)
-    return a.basis == b.basis
-end
 
 struct AlgebraElement{A,T,V} <: MA.AbstractMutable
     coeffs::V

--- a/src/types.jl
+++ b/src/types.jl
@@ -26,6 +26,9 @@ end
 
 basis(A::StarAlgebra) = A.basis
 object(A::StarAlgebra) = A.object
+function Base.:(==)(a::StarAlgebra, b::StarAlgebra)
+    return a.basis == b.basis
+end
 
 struct AlgebraElement{A,T,V} <: MA.AbstractMutable
     coeffs::V

--- a/src/types.jl
+++ b/src/types.jl
@@ -90,7 +90,7 @@ function Base.isone(a::AlgebraElement)
     if basis(A) isa DiracBasis
         return c == cfs1
     else
-        dc = coeffs(c, basis(parent(a)), DiracBasis{UInt}(object(parent(a))))
+        dc = coeffs(c, basis(a), DiracBasis{UInt}(object(parent(a))))
         return dc == cfs1
     end
 end

--- a/src/types.jl
+++ b/src/types.jl
@@ -27,6 +27,8 @@ end
 basis(A::StarAlgebra) = A.basis
 object(A::StarAlgebra) = A.object
 
+function algebra end
+
 struct AlgebraElement{A,T,V} <: MA.AbstractMutable
     coeffs::V
     parent::A

--- a/test/caching_allocations.jl
+++ b/test/caching_allocations.jl
@@ -52,6 +52,7 @@ end
         Y * Y
         k2 = @allocated Y * Y
         @test k2 / k1 < 0.7
+        @test_broken k2 / k1 < 0.12
     end
 
     @test all(!iszero, SA.mstructure(fRG).table)

--- a/test/caching_allocations.jl
+++ b/test/caching_allocations.jl
@@ -51,8 +51,7 @@ end
         @test Y * Y isa AlgebraElement
         Y * Y
         k2 = @allocated Y * Y
-        @test k2 / k1 < 0.7
-        @test_broken k2 / k1 < 0.12
+        @test k2 / k1 < 0.12
     end
 
     @test all(!iszero, SA.mstructure(fRG).table)

--- a/test/group_algebra.jl
+++ b/test/group_algebra.jl
@@ -115,7 +115,7 @@
         z = sum((one(RG) - RG(g)) * star(one(RG) - RG(g)) for g in G)
         @test SA.aug(z) == 0
 
-        @test SA.supp(z) == sort(collect(basis(parent(z))))
+        @test SA.supp(z) == sort(collect(basis(z)))
         @test SA.supp(RG(1) + RG(g)) == [one(G), g]
         @test SA.supp(a) == [one(G), h, g]
 


### PR DESCRIPTION
as suspected calling canonical on `Tuple`-based `SparseCoefficients` is not a good idea.
And these are actually immutable. For the time being adding this one overload brings back the allocations AND performance of `*`.

Fixes #36

@blegat is the mutability trait even needed now?

EDIT: test will fail due to broken test now fixed.