### PR TITLE
Allow coeffs not defining zero

### DIFF
--- a/src/sparse_coeffs.jl
+++ b/src/sparse_coeffs.jl
@@ -17,7 +17,11 @@ function Base.getindex(sc::SparseCoefficients{K}, key::K) where {K}
     k = searchsortedfirst(sc.basis_elements, key; lt = comparable(K))
     if k in eachindex(sc.basis_elements)
         v = sc.values[k]
-        return ifelse(sc.basis_elements[k] == key, v, zero(v))
+        if sc.basis_elements[k] == key
+            return v
+        else
+            return zero(v)
+        end
     else
         return zero(valtype(sc))
     end

--- a/test/constructors.jl
+++ b/test/constructors.jl
@@ -109,12 +109,14 @@ end
     @test parent(deepcopy(a)) === parent(a)
 
     latex = CustomLaTeXPrint(" \$\$ \\[\\(α_β∀ \\) \\]\t  \$\$")
-    @test sprint((io, x) -> show(io, "text/latex", x),
-        SA.AlgebraElement(SA.SparseCoefficients([p], [latex]), RG)) ==
+    a = SA.AlgebraElement(SA.SparseCoefficients([p], [latex]), RG)
+    @test SA.coeffs(a)[p] == latex
+    @test sprint((io, x) -> show(io, "text/latex", x), a) ==
           "\$\$ (α_β∀) \\cdot b·c \$\$"
     # Test that the check for `\\)` handles unicode well
     latex = CustomLaTeXPrint("\\(β∀")
     @test sprint((io, x) -> show(io, "text/latex", x),
         SA.AlgebraElement(SA.SparseCoefficients([p], [latex]), RG)) ==
           "\$\$ (\\(β∀) \\cdot b·c \$\$"
+    
 end

--- a/test/constructors.jl
+++ b/test/constructors.jl
@@ -110,6 +110,7 @@ end
 
     latex = CustomLaTeXPrint(" \$\$ \\[\\(α_β∀ \\) \\]\t  \$\$")
     a = SA.AlgebraElement(SA.SparseCoefficients([p], [latex]), RG)
+    # Tests that `getindex` works even if `zero(typeof(latex))` is not defined
     @test SA.coeffs(a)[p] == latex
     @test sprint((io, x) -> show(io, "text/latex", x), a) ==
           "\$\$ (α_β∀) \\cdot b·c \$\$"


### PR DESCRIPTION
The issue with `ifelse` is that the `else` is always executed, even if the key is present. This is needed for SumOfSquares.