### PR TITLE
Remove specialized methods

### DIFF
--- a/src/arithmetic.jl
+++ b/src/arithmetic.jl
@@ -133,3 +133,8 @@ function unsafe_push!(a::SparseArrays.SparseVector, k, v)
     a[k] = MA.add!!(a[k], v)
     return a
 end
+
+function unsafe_push!(a::Vector, k, v)
+    a[k] = MA.add!!(a[k], v)
+    return a
+end

--- a/src/mtables.jl
+++ b/src/mtables.jl
@@ -97,23 +97,6 @@ _key(mstr::MTable, k) = mstr[k]
 
 function MA.operate!(
     ms::UnsafeAddMul{<:MTable},
-    res::AbstractCoefficients,
-    v::AbstractCoefficients,
-    w::AbstractCoefficients,
-)
-    for (kv, a) in nonzero_pairs(v)
-        for (kw, b) in nonzero_pairs(w)
-            c = ms.structure(kv, kw)
-            for (k, v) in nonzero_pairs(c)
-                res[ms.structure[k]] += v * a * b
-            end
-        end
-    end
-    return res
-end
-
-function MA.operate!(
-    ms::UnsafeAddMul{<:MTable},
     res::AbstractSparseVector,
     v::AbstractVector,
     w::AbstractVector,
@@ -136,22 +119,5 @@ function MA.operate!(
         end
     end
     res .+= sparsevec(idcs, vals, length(res))
-    return res
-end
-
-function MA.operate!(
-    ms::UnsafeAddMul{<:MTable},
-    res::AbstractVector,
-    v::AbstractVector,
-    w::AbstractVector,
-)
-    for (kv, a) in nonzero_pairs(v)
-        for (kw, b) in nonzero_pairs(w)
-            c = ms.structure(kv, kw)
-            for (k, v) in nonzero_pairs(c)
-                res[ms.structure[k]] += v * a * b
-            end
-        end
-    end
     return res
 end

--- a/test/test_example_acoeffs.jl
+++ b/test/test_example_acoeffs.jl
@@ -26,6 +26,6 @@ end
 Base.getindex(ac::ACoeffs, idx) = ac.vals[idx]
 Base.setindex!(ac::ACoeffs, val, idx) = ac.vals[idx] = val
 function SA.unsafe_push!(ac::ACoeffs, idx, val)
-    ac.vals[idx] = val
+    ac.vals[idx] = MA.add!!(ac.vals[idx], val)
     return ac
 end

--- a/test/test_example_acoeffs.jl
+++ b/test/test_example_acoeffs.jl
@@ -25,3 +25,7 @@ end
 # the default arithmetic implementation uses this access
 Base.getindex(ac::ACoeffs, idx) = ac.vals[idx]
 Base.setindex!(ac::ACoeffs, val, idx) = ac.vals[idx] = val
+function SA.unsafe_push!(ac::ACoeffs, idx, val)
+    ac.vals[idx] = val
+    return ac
+end


### PR DESCRIPTION
These now do the same as the generic one added in https://github.com/JuliaAlgebra/StarAlgebras.jl/pull/46