### PR TITLE
Fix similar for Tuple

### DIFF
--- a/src/arithmetic.jl
+++ b/src/arithmetic.jl
@@ -80,8 +80,8 @@ function MA.operate_to!(
     X::AlgebraElement,
     Y::AlgebraElement,
 )
-    @assert parent(res) === parent(X)
-    @assert parent(X) === parent(Y)
+    @assert parent(res) == parent(X)
+    @assert parent(X) == parent(Y)
     MA.operate_to!(coeffs(res), +, coeffs(X), coeffs(Y))
     return res
 end

--- a/src/sparse_coeffs.jl
+++ b/src/sparse_coeffs.jl
@@ -42,8 +42,13 @@ function Base.zero(sc::SparseCoefficients)
     return SparseCoefficients(empty(keys(sc)), empty(values(sc)))
 end
 
+_similar(x::Tuple) = _similar(x, typeof(x[1]))
+_similar(x::Tuple, ::Type{T}) where {T} = Vector{T}(undef, length(x))
+_similar(x) = similar(x)
+_similar(x, ::Type{T}) where {T} = similar(x, T)
+
 function Base.similar(s::SparseCoefficients, ::Type{T} = valtype(s)) where {T}
-    return SparseCoefficients(similar(s.basis_elements), similar(s.values, T))
+    return SparseCoefficients(_similar(s.basis_elements), _similar(s.values, T))
 end
 
 function MA.mutability(

--- a/test/caching_allocations.jl
+++ b/test/caching_allocations.jl
@@ -68,3 +68,28 @@ end
         _alloc_test(YY, +, Y, YY, 2)
     end
 end
+
+@testset "tuple" begin
+    alph = [:a, :b, :c]
+    A★ = FreeWords(alph)
+    B = SA.DiracBasis(A★)
+
+    fB = SA.FixedBasis(B; n = nwords(A★, 2), mt = UInt32(nwords(A★, 2)))
+    fRG = StarAlgebra(A★, fB)
+
+    y = SA.SparseCoefficients(
+        [first(fB)],
+        [1],
+    )
+    Y = AlgebraElement(y, fRG)
+
+    z = SA.SparseCoefficients(
+        (first(fB),),
+        (1,),
+    )
+    Z = AlgebraElement(z, fRG)
+    @test Z + Z == 2 * Z
+    @test Z + Z == Y + Y
+    @test Y + Z == Y + Y
+    @test Z + Y == Y + Y
+end


### PR DESCRIPTION
When we do `a * b` and `a` is uses `Tuple` as container, we should switch to `Vector` so that it can be mutated. `similar` isn't defined for `Tuple` anyway so this is currently a `MethodError`