### PR TITLE
Broadcast star

### DIFF
--- a/src/star.jl
+++ b/src/star.jl
@@ -6,7 +6,7 @@ function star(X::AlgebraElement)
     return AlgebraElement(res, parent(X))
 end
 
-star(::AbstractBasis, x) = star(x)
+star(::AbstractBasis, x) = star.(x)
 
 function star(basis::AbstractBasis, d::SparseCoefficients)
     k = star.(Ref(basis), keys(d))


### PR DESCRIPTION
This is called on `x` being the vector of coefficient so `star(x)` will be an adjoint vector which is not what we want.
Luckily, we implemented broadcasting for `SparseCoefficients` in https://github.com/JuliaAlgebra/StarAlgebras.jl/pull/53