### PR TITLE
fix issues with zero one

### DIFF
--- a/examples/natural.jl
+++ b/examples/natural.jl
@@ -8,5 +8,6 @@ Base.eltype(::NaturalNumbers) = Int
 Base.iterate(::NaturalNumbers) = (1, 1)
 Base.iterate(::NaturalNumbers, state) = (state + 1, state + 1)
 Base.in(i::Int, ::NaturalNumbers) = i >= 1
+Base.one(::NaturalNumbers) = 1
 
 function Base.require_one_based_indexing(::SA.MappedBasis{T,Int,NaturalNumbers}) where {T} end

--- a/src/diracs_augmented.jl
+++ b/src/diracs_augmented.jl
@@ -2,11 +2,11 @@
 # Copyright (c) 2021-2025: Marek Kaluba, Benoît Legat
 
 aug(cfs::Any) = sum(values(cfs))
-aug(a::AlgebraElement) = aug(coeffs(a))
+aug(a::AlgebraElement) = aug(coeffs(a), basis(a))
 
-function aug(ac::AbstractCoefficients)
-    isempty(keys(ac)) && return zero(value_type(ac))
-    return sum(c * aug(x) for (x, c) in nonzero_pairs(ac))
+function aug(cfs, b::AbstractBasis)
+    isempty(keys(cfs)) && return zero(value_type(cfs))
+    return sum(c * aug(b[x]) for (x, c) in nonzero_pairs(cfs))
 end
 
 struct Augmented{K} <: AbstractCoefficients{K,Int}

--- a/src/types.jl
+++ b/src/types.jl
@@ -33,7 +33,7 @@ function MA.promote_operation(::typeof(basis), ::Type{StarAlgebra{O,T,M}}) where
     return MA.promote_operation(basis, M)
 end
 object(A::StarAlgebra) = A.object
-Base.isempty(A::StarAlgebra) = isempty(object(A))
+Base.isempty(A::StarAlgebra) = isempty(basis(A))
 
 struct AlgebraElement{A,T,V} <: MA.AbstractMutable
     coeffs::V
@@ -50,8 +50,6 @@ function MA.promote_operation(::typeof(coeffs), ::Type{AlgebraElement{A,T,V}}) w
     return V
 end
 coeffs(a::AlgebraElement) = a.coeffs
-
-
 
 function MA.operate!(T::typeof(canonical), a::AlgebraElement)
     return MA.operate!(T, coeffs(a))

--- a/src/types.jl
+++ b/src/types.jl
@@ -33,6 +33,7 @@ function MA.promote_operation(::typeof(basis), ::Type{StarAlgebra{O,T,M}}) where
     return MA.promote_operation(basis, M)
 end
 object(A::StarAlgebra) = A.object
+Base.isempty(A::StarAlgebra) = isempty(object(A))
 
 struct AlgebraElement{A,T,V} <: MA.AbstractMutable
     coeffs::V
@@ -40,6 +41,8 @@ struct AlgebraElement{A,T,V} <: MA.AbstractMutable
 end
 
 Base.parent(a::AlgebraElement) = a.parent
+Base.in(x::AlgebraElement, A::AbstractStarAlgebra) = parent(x) == A
+
 mstructure(a::AlgebraElement) = mstructure(parent(a))
 Base.eltype(::Type{A}) where {A<:AlgebraElement} = value_type(MA.promote_operation(coeffs, A))
 Base.eltype(a::AlgebraElement) = eltype(typeof(a))
@@ -47,6 +50,8 @@ function MA.promote_operation(::typeof(coeffs), ::Type{AlgebraElement{A,T,V}}) w
     return V
 end
 coeffs(a::AlgebraElement) = a.coeffs
+
+
 
 function MA.operate!(T::typeof(canonical), a::AlgebraElement)
     return MA.operate!(T, coeffs(a))
@@ -84,7 +89,7 @@ function __coerce(A::AbstractStarAlgebra, (x,v)::Pair{K, V}) where {K,V}
         cfs[basis(A)[x]] = v
         return AlgebraElement(cfs, A)
     # elseif x in object(A)
-    #     sc = SparseCoefficients([basis(A)[x]], [v])
+    #     sc = SparseCoefficients([x], [v])
     #     return AlgebraElement(
     #         coeffs(sc, DiracBasis(object(A)), basis(A)),
     #         A,
@@ -115,7 +120,8 @@ function Base.isone(a::AlgebraElement)
         end
         return true
     else
-        return a == one(a)
+        throw(ArgumentError("basis of $A does not contain $id; `one` and `isone` are unsupported"))
+        # return a == one(a)
     end
 end
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -76,7 +76,7 @@ function AlgebraElement(
 end
 
 ### constructing elements
-function __coerce(A::AbstractStarAlgebra{O,T}, (x,v)::Pair{T, V}) where {O,T,V}
+function __coerce(A::AbstractStarAlgebra, (x,v)::Pair{K, V}) where {K,V}
     if iszero(v)
         return AlgebraElement(zero_coeffs(V, basis(A)), A)
     elseif x in basis(A)

--- a/test/basic.jl
+++ b/test/basic.jl
@@ -1,6 +1,9 @@
 # This file is a part of StarAlgebras.jl. License is MIT: https://github.com/JuliaAlgebra/StarAlgebras.jl/blob/main/LICENSE
 # Copyright (c) 2021-2025: Marek Kaluba, Benoît Legat
 
+struct PlaceholderObject end
+Base.one(::PlaceholderObject) = 1
+
 struct DummyBasis{T} <: SA.ExplicitBasis{T,Int}
     elements::Vector{T}
 end
@@ -10,7 +13,7 @@ Base.getindex(b::DummyBasis, i::Int) = b.elements[i]
 
 @testset "Basic tests" begin
     b = DummyBasis(Irrational[π, ℯ])
-    a = StarAlgebra(nothing, b)
+    a = StarAlgebra(PlaceholderObject(), b)
     s(i) = sprint(show, MIME"text/plain"(), i)
     @test sprint(show, AlgebraElement([2, -1], a)) == "2·$(s(π)) - 1·$(s(ℯ))"
 end

--- a/test/perm_grp_algebra.jl
+++ b/test/perm_grp_algebra.jl
@@ -179,9 +179,10 @@ import StarAlgebras as SA
         S = unique!([a * b for a in S1 for b in S1])
 
         elts = [RG(g) - RG(1) for g in S]
-        elts[begin] = RG(1) # we don't want to have zero in the basis
-
+        elts[begin] = RG(S[2]) + RG(1)
         ab = SA.FixedBasis(elts)
+        # basis looks like this: [s₁ + e, s₁ - e, s₂ - e, s₃ - e, …]
+        # in particular it doesn't contain 1!
 
         @test ab[ab[elts[2]]] == elts[2]
 
@@ -195,17 +196,13 @@ import StarAlgebras as SA
         ar = SA.AlgebraElement(coeffs(rcfs, SA.DiracBasis(elts), basis(aRG)), aRG)
         as = SA.AlgebraElement(coeffs(scfs, SA.DiracBasis(elts), basis(aRG)), aRG)
 
-        @test SA.aug(ar) == ar(ab[1]) # one(RG)
-        @test SA.aug(as) == as(ab[1]) # one(RG)
+        @test SA.aug(ar) == 2*ar(first(ab)) # one(RG)
+        @test SA.aug(as) == 2as(first(ab)) # one(RG)
         @test SA.aug(ar + as) == SA.aug(ar) + SA.aug(as)
 
         @test coeffs(ar + as, basis(aRG)) isa AbstractVector
 
-        @test isone(one(aRG))
-        @test ar * one(aRG) == ar
-        @test one(aRG) * ar == ar
-        @test eltype(one(Float64, aRG)) == Float64
-        @test isone(one(ar))
-        @test coeffs(one(ar)) == coeffs(one(aRG))
+        @test_throws ArgumentError one(aRG)
+        @test_throws ArgumentError isone(ar)
     end
 end

--- a/test/perm_grp_algebra.jl
+++ b/test/perm_grp_algebra.jl
@@ -174,4 +174,38 @@ import StarAlgebras as SA
             @test coeffs(one(x)) == coeffs(one(sRG))
         end
     end
+    @testset "Algebra Elements Basis" begin
+        S1 = unique!(collect(Iterators.take(G, 10)))
+        S = unique!([a * b for a in S1 for b in S1])
+
+        elts = [RG(g) - RG(1) for g in S]
+        elts[begin] = RG(1) # we don't want to have zero in the basis
+
+        ab = SA.FixedBasis(elts)
+
+        @test ab[ab[elts[2]]] == elts[2]
+
+        rcfs = SA.SparseCoefficients(rand(elts[1:length(S1)], 5), rand(-2:2, 5))
+        scfs = SA.SparseCoefficients(rand(elts[1:length(S1)], 5), rand(-2:2, 5))
+
+        @test coeffs(rcfs, SA.DiracBasis(elts), ab) isa SparseVector
+
+        aRG = SA.StarAlgebra(RG, SA.MTable(ab, (length(S1), length(S1))))
+
+        ar = SA.AlgebraElement(coeffs(rcfs, SA.DiracBasis(elts), basis(aRG)), aRG)
+        as = SA.AlgebraElement(coeffs(scfs, SA.DiracBasis(elts), basis(aRG)), aRG)
+
+        @test SA.aug(ar) == ar(ab[1]) # one(RG)
+        @test SA.aug(as) == as(ab[1]) # one(RG)
+        @test SA.aug(ar + as) == SA.aug(ar) + SA.aug(as)
+
+        @test coeffs(ar + as, basis(aRG)) isa AbstractVector
+
+        @test isone(one(aRG))
+        @test ar * one(aRG) == ar
+        @test one(aRG) * ar == ar
+        @test eltype(one(Float64, aRG)) == Float64
+        @test isone(one(ar))
+        @test coeffs(one(ar)) == coeffs(one(aRG))
+    end
 end

--- a/test/perm_grp_algebra.jl
+++ b/test/perm_grp_algebra.jl
@@ -37,6 +37,13 @@ import StarAlgebras as SA
     xz = SA.AlgebraElement(xzcfs, RG)
     @test x * z == xz
 
+    @test isone(one(RG))
+    @test x * one(RG) == x
+    @test one(RG) * x == x
+    @test eltype(one(Float64, RG)) == Float64
+    @test isone(one(x))
+    @test coeffs(one(x)) == coeffs(one(RG))
+
     # FIXME Broken
 #    @testset "Augmented basis" begin
 #        ad = SA.AugmentedBasis(db)
@@ -102,6 +109,13 @@ import StarAlgebras as SA
             count(i -> isassigned(mt, i), eachindex(mt)), length(mt)
         end
         @test a ≤ b
+
+        @test isone(one(fRG))
+        @test fr * one(fRG) == fr
+        @test one(fRG) * fr == fr
+        @test eltype(one(Float64, fRG)) == Float64
+        @test isone(one(fr))
+        @test coeffs(one(fr)) == coeffs(one(fRG))
     end
 
     @testset "SubBasis" begin
@@ -122,7 +136,7 @@ import StarAlgebras as SA
         @test only(smstr(1, 2).basis_elements) == subb[subb[1] * subb[2]]
         @test only(smstr(1, 2, eltype(subb)).basis_elements) == subb[1] * subb[2]
 
-        sbRG = SA.StarAlgebra(G, subb)
+        sbRG = SA.StarAlgebra(G, smstr)
 
         x = let z = zeros(Int, length(SA.basis(sbRG)))
             z[1:length(S1)] .= rand(-1:1, length(S1))
@@ -140,5 +154,24 @@ import StarAlgebras as SA
         @test dx + dy == SA.AlgebraElement(SA.coeffs(x + y, SA.basis(RG)), RG)
 
         @test dx * dy == SA.AlgebraElement(SA.coeffs(x * y, SA.basis(RG)), RG)
+
+        if !(one(G) in subb)
+            @test_throws ArgumentError one(sbRG)
+        end
+
+        S2 = unique([S; one(G)])
+        subb2 = SA.SubBasis(db, S2)
+        let sRG = SA.StarAlgebra(G, subb2)
+            x = let z = spzeros(Int, length(SA.basis(sRG)))
+                z[rand(1:length(S2), 10)] += rand(-1:1, 10)
+                SA.AlgebraElement(z, sRG)
+            end
+            @test isone(one(sRG))
+            @test x * one(sRG) == x
+            @test one(sRG) * x == x
+            @test eltype(one(Float64, sRG)) == Float64
+            @test isone(one(x))
+            @test coeffs(one(x)) == coeffs(one(sRG))
+        end
     end
 end

--- a/test/quadratic_form.jl
+++ b/test/quadratic_form.jl
@@ -92,7 +92,7 @@ end
         true  false true
     ]
     Q = SA.QuadraticForm(Gram(m, explicit))
-    A = SA.StarAlgebra(nothing, implicit)
+    A = SA.StarAlgebra(PlaceholderObject(), implicit)
     @test A(Q) == SA.AlgebraElement(
         SA.SparseCoefficients(
             [1.0, 3.0, 4.0, 9.0],
@@ -123,7 +123,7 @@ end
             1 // 2 0      2
             0      2      1
         ]
-        A = SA.StarAlgebra(nothing, mult)
+        A = SA.StarAlgebra(PlaceholderObject(), mult)
         for explicit in [sub, fixed]
             Q = SA.QuadraticForm(Gram(m, explicit))
             @test A(Q) == SA.AlgebraElement(


### PR DESCRIPTION
there's one commented out branch in `__coerce` that would require us to handle one more example, but this requires that `object(A)` is iterable, which might be too much? I'm not sure if the case covered by it is worth the trouble.

closes #80
closes #60 