### PR TITLE
Implement copy for bases

### DIFF
--- a/src/bases_dirac.jl
+++ b/src/bases_dirac.jl
@@ -101,6 +101,8 @@ function MappedBasis(itr, map, inverse_map)
     return MappedBasis{typeof(map(first(itr)))}(itr, map, inverse_map)
 end
 
+Base.copy(b::MappedBasis) = b
+
 object(db::MappedBasis) = db.object
 
 function Base.IteratorSize(::Type{<:MappedBasis{T,I,S}}) where {T,I,S}

--- a/src/bases_fixed.jl
+++ b/src/bases_fixed.jl
@@ -106,6 +106,8 @@ struct SubBasis{T,I,K,B<:AbstractBasis{T,K},V<:AbstractVector{K}} <:
     end
 end
 
+Base.copy(b::SubBasis) = SubBasis(copy(parent(b)), copy(b.keys))
+
 Base.parent(sub::SubBasis) = sub.parent_basis
 
 Base.length(b::SubBasis) = length(b.keys)


### PR DESCRIPTION
This is needed to pass the tests of MultivariateBases:  https://github.com/JuliaAlgebra/MultivariateBases.jl/pull/57. It's not clear why it's needed though since SumOfSquares does not seem to use it:
https://github.com/jump-dev/SumOfSquares.jl/blob/2c40b50abcc31b89111f07d62c0c05752be9d8a1/src/sets.jl#L149
Let's not merge it for now, I'll check if that's really needed
**EDIT** used by SOS here:
https://github.com/jump-dev/SumOfSquares.jl/blob/ba0f7b09b2ad5a8b7e8eaef7acd040835d325bfb/src/Bridges/Constraint/sos_polynomial.jl#L65-L68