### PR TITLE
Don't add coefficients in basis conversion

### DIFF
--- a/src/bases.jl
+++ b/src/bases.jl
@@ -84,7 +84,7 @@ function coeffs!(res, cfs, source::AbstractBasis, target::AbstractBasis)
     MA.operate!(zero, res)
     for (k, v) in nonzero_pairs(cfs)
         x = source[k]
-        res[target[x]] += v
+        res[target[x]] = v
     end
     return res
 end


### PR DESCRIPTION
This is needed for https://github.com/JuliaAlgebra/MultivariateBases.jl/pull/57.
I'm not sure how it was passing before that PR but looking at the code, it's unclear why we could need `+=` instead of `=` unless we expect that there are duplicates in `cfs` and that it's not canonical ? I think we assume that it's always canonicalized unless inside `UnsafeAddMul`.
Again, let's not merge this right away, I'll check if that's the right fix