### PR TITLE
Improve error message for different key types

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -7,7 +7,7 @@ function _key_type_check(coeffs, A::AbstractStarAlgebra)
     KC = key_type(coeffs)
     KA = key_type(basis(A))
     if KC != KA
-        error("The key type `$KC` of the coefficients does not match the key type `$KA` of the algebra")
+        throw(ArgumentError("The key type `$KC` of the coefficients does not match the key type `$KA` of the algebra `$A`"))
     end
 end
 

--- a/test/constructors.jl
+++ b/test/constructors.jl
@@ -47,7 +47,7 @@ end
         MA.operate!(SA.canonical, coeffs)
     end
 
-    err = ArgumentError("The key type `Int64` of the coefficients does not match the key type `Word{Symbol}` of the algebra")
+    err = ArgumentError("The key type `Int64` of the coefficients does not match the key type `Word{Symbol}` of the algebra `*-algebra of FreeWords{Symbol}([:a, :b, :c])`")
     bad_coeffs = SA.SparseCoefficients([1], [2])
     @test_throws err AlgebraElement(bad_coeffs, RG)
 


### PR DESCRIPTION
This is more helpful when debugging
Actually we could turn all `@assert` to `@argcheck` from https://github.com/jw3126/ArgCheck.jl/