### PR TITLE
Fix AugmentedBasis to work with current StarAlgebras API

### DIFF
--- a/examples/diracs_augmented.jl
+++ b/examples/diracs_augmented.jl
@@ -51,7 +51,7 @@ Base.isless(ad1::Augmented, ad2::Augmented) = isless(ad1.elt, ad2.elt)
 aug(::Augmented) = 0
 
 struct AugmentedBasis{T,I,A<:Augmented{T},B<:SA.AbstractBasis{T,I}} <:
-       SA.ImplicitBasis{A,I}
+       SA.ImplicitBasis{A,A}
     basis::B
 end
 
@@ -95,13 +95,39 @@ function Base.getindex(ab::AugmentedBasis{T,I,A}, x::A) where {T,I,A}
     return x
 end
 
-SA.mstructure(db::AugmentedBasis) = AugmentedMStructure(SA.mstructure(db.basis))
+function Base.:(==)(a::AugmentedBasis, b::AugmentedBasis)
+    return a.basis == b.basis
+end
 
-struct AugmentedMStructure{T,I,M<:SA.DiracMStructure{T,I}} <: SA.MultiplicativeStructure{T,I}
+struct AugmentedMStructure{A,B<:AugmentedBasis,M<:SA.DiracMStructure} <:
+       SA.MultiplicativeStructure{A,A}
+    basis::B
     op::M
 end
 
-function (mstr::AugmentedMStructure)(aδx::Augmented, aδy::Augmented)
+function AugmentedMStructure(ab::AugmentedBasis{T,I,A}) where {T,I,A}
+    op = SA.DiracMStructure(ab.basis, *)
+    return AugmentedMStructure{A,typeof(ab),typeof(op)}(ab, op)
+end
+
+SA.mstructure(ab::AugmentedBasis) = AugmentedMStructure(ab)
+
+function MA.promote_operation(
+    ::typeof(SA.basis),
+    ::Type{<:AugmentedMStructure{A,B}},
+) where {A,B}
+    return B
+end
+
+function Base.:(==)(a::AugmentedMStructure, b::AugmentedMStructure)
+    return a.basis == b.basis && a.op == b.op
+end
+
+function SA.StarAlgebra(object, ab::AugmentedBasis)
+    return SA.StarAlgebra(object, SA.mstructure(ab))
+end
+
+function (mstr::AugmentedMStructure)(aδx::A, aδy::A, ::Type{A}) where {A<:Augmented}
     δxy = first(keys(mstr.op(aδx.elt, aδy.elt)))
     if isone(δxy)
         return SA.SparseCoefficients((aδx, aδy), (-1, -1))
@@ -127,11 +153,7 @@ function SA.coeffs!(
     for (k, v) in SA.nonzero_pairs(cfs)
         isone(k) && continue
         x = source[k]
-        MA.operate!(
-            SA.UnsafeAddMul(*),
-            res,
-            SA.SparseCoefficients((target[Augmented(x)],), (v,)),
-        )
+        SA.unsafe_push!(res, target[Augmented(x)], v)
     end
     MA.operate!(SA.canonical, res)
     return res

--- a/examples/diracs_augmented.jl
+++ b/examples/diracs_augmented.jl
@@ -127,6 +127,14 @@ function SA.StarAlgebra(object, ab::AugmentedBasis)
     return SA.StarAlgebra(object, SA.mstructure(ab))
 end
 
+function SA.promote_bases_with_maps(
+    a::AugmentedMStructure,
+    b::AugmentedMStructure,
+)
+    _a, _b = SA.promote_bases_with_maps(SA.basis(a), SA.basis(b))
+    return SA.maybe_promote(a, _a...), SA.maybe_promote(b, _b...)
+end
+
 function (mstr::AugmentedMStructure)(aδx::A, aδy::A, ::Type{A}) where {A<:Augmented}
     δxy = first(keys(mstr.op(aδx.elt, aδy.elt)))
     if isone(δxy)

--- a/test/perm_grp_algebra.jl
+++ b/test/perm_grp_algebra.jl
@@ -44,33 +44,32 @@ import StarAlgebras as SA
     @test isone(one(x))
     @test coeffs(one(x)) == coeffs(one(RG))
 
-    # FIXME Broken
-    #    @testset "Augmented basis" begin
-    #        ad = AugmentedBasis(db)
-    #        @test SA.mstructure(ad) == AugmentedMStructure(SA.mstructure(db))
-    #        @test ad[Augmented(h)] isa Augmented
-    #        @test sprint(show, ad[Augmented(h)]) == "(-1·()+1·(1,2,4,5))"
-    #
-    #        @test !(h in ad)
-    #        @test Augmented(h) in ad
-    #
-    #        IG = SA.StarAlgebra(G, ad)
-    #
-    #        axcfs = SA.coeffs(x, basis(IG))
-    #        aycfs = SA.coeffs(y, basis(IG))
-    #        azcfs = SA.coeffs(z, basis(IG))
-    #        ax = SA.AlgebraElement(axcfs, IG)
-    #        ay = SA.AlgebraElement(aycfs, IG)
-    #        az = SA.AlgebraElement(azcfs, IG)
-    #
-    #        @test coeffs(ax * ay) == SA.coeffs(x * y, basis(IG))
-    #        @test coeffs(ax * az) == SA.coeffs(x * z, basis(IG))
-    #        @test aug(ax) == 0
-    #        @test star(ax) * star(ay) == star(ay) * star(ax)
-    #
-    #        @test length(ad) == length(db) - 1
-    #        @test Set(ad) == Set(Augmented(g) for g in db if !isone(g))
-    #    end
+    @testset "Augmented basis" begin
+        ad = AugmentedBasis(db)
+        @test SA.mstructure(ad) == AugmentedMStructure(ad)
+        @test ad[Augmented(h)] isa Augmented
+        @test sprint(show, ad[Augmented(h)]) == "(-1·()+1·(1,2,4,5))"
+
+        @test !(h in ad)
+        @test Augmented(h) in ad
+
+        IG = SA.StarAlgebra(G, ad)
+
+        axcfs = SA.coeffs(x, basis(IG))
+        aycfs = SA.coeffs(y, basis(IG))
+        azcfs = SA.coeffs(z, basis(IG))
+        ax = SA.AlgebraElement(axcfs, IG)
+        ay = SA.AlgebraElement(aycfs, IG)
+        az = SA.AlgebraElement(azcfs, IG)
+
+        @test coeffs(ax * ay) == SA.coeffs(x * y, basis(IG))
+        @test coeffs(ax * az) == SA.coeffs(x * z, basis(IG))
+        @test aug(ax) == 0
+        @test star(ax) * star(ay) == star(ay) * star(ax)
+
+        @test length(ad) == length(db) - 1
+        @test Set(ad) == Set(Augmented(g) for g in db if !isone(g))
+    end
 
     @testset "Random elements (seed=$seed)" for seed in 0:20
         Random.seed!(seed)


### PR DESCRIPTION
The AugmentedBasis was broken after PR #49 changed the basis/coefficient
architecture. The core issues were:

1. AugmentedBasis extended ImplicitBasis{A,I} with key type I (group
   element type), but coefficients need Augmented{T} keys. Changed to
   ImplicitBasis{A,A} so key type matches element type.

2. AugmentedMStructure used the inner DiracMStructure's type params and
   didn't store the basis. Redesigned to use Augmented{T} type params,
   store the AugmentedBasis (so basis(mstr) works via the default), and
   added a constructor from AugmentedBasis.

3. The mstructure callable had a 2-arg signature that conflicted with
   MultiplicativeStructure dispatch. Changed to 3-arg signature
   (aδx, aδy, ::Type{A}) to integrate with the dispatch chain.

4. coeffs! used a non-existent 3-arg UnsafeAddMul overload. Replaced
   with direct unsafe_push! calls.

5. Added StarAlgebra(object, ::AugmentedBasis) constructor, equality
   methods, and MA.promote_operation for type inference.

Closes #50

https://claude.ai/code/session_01NToyuRQU8J18VoEeXpBq8c